### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,10 +1,13 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to v11.6.0
+        run: npm install -g npm@11.6.0
       - run: npm ci
       - name: build binary
         run: npm run buildTS
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![npm version](https://badge.fury.io/js/@masatomakino%2Fpixijs-particle-waypoint.svg)](https://badge.fury.io/js/@masatomakino%2Fpixijs-particle-waypoint)
 [![build](https://github.com/MasatoMakino/pixijs-particle-waypoint/actions/workflows/ci_main.yml/badge.svg?branch=main)](https://github.com/MasatoMakino/pixijs-particle-waypoint/actions/workflows/ci_main.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/90eacb3e6a78a7344b9b/maintainability)](https://codeclimate.com/github/MasatoMakino/pixijs-particle-waypoint/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/90eacb3e6a78a7344b9b/test_coverage)](https://codeclimate.com/github/MasatoMakino/pixijs-particle-waypoint/test_coverage)
 
 [![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=pixijs-particle-waypoint)](https://github.com/MasatoMakino/pixijs-particle-waypoint)
 


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication.

## Changes

- ✅ Added OIDC permissions to GitHub Actions workflow (`id-token: write`, `contents: read`)
- ✅ Added npm upgrade step for latest OIDC support (`npm install -g npm@11.6.0`)
- ✅ Removed NPM token authentication from workflow
- ✅ Fixed release trigger to use `types: [published]` instead of `types: [created]`
- ✅ Removed CodeClimate badges from README

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

The migration can be tested by creating a release after this PR is merged. The workflow should successfully publish to NPM using Trusted Publisher authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Maintainability and Test Coverage badges from the README; remaining badges unchanged.

* **Chores**
  * Updated release workflow to run on published releases.
  * Upgraded npm to v11.6.0 in the publishing pipeline.
  * Adopted OIDC-based permissions and removed token-based environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->